### PR TITLE
Fix Mesh Collider Error on Pickups.

### DIFF
--- a/Assets/Prefabs/GamePlay/Items/Criasium Capacitor.prefab
+++ b/Assets/Prefabs/GamePlay/Items/Criasium Capacitor.prefab
@@ -21,8 +21,8 @@ GameObject:
   - component: {fileID: 4887947712083116}
   - component: {fileID: 33433823989278620}
   - component: {fileID: 23125762744368210}
-  - component: {fileID: 64657229832120198}
   - component: {fileID: 114552916428876982}
+  - component: {fileID: 135960341593254118}
   m_Layer: 0
   m_Name: Model
   m_TagString: Untagged
@@ -212,7 +212,7 @@ Transform:
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 1996120002971910}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 58.3, y: 1, z: 82.2}
+  m_LocalPosition: {x: 55.4, y: 1, z: 27.1}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
   - {fileID: 4887947712083116}
@@ -231,8 +231,8 @@ MeshRenderer:
   m_CastShadows: 2
   m_ReceiveShadows: 1
   m_MotionVectors: 1
-  m_LightProbeUsage: 1
-  m_ReflectionProbeUsage: 1
+  m_LightProbeUsage: 0
+  m_ReflectionProbeUsage: 0
   m_Materials:
   - {fileID: 2100000, guid: 000c9daec349fad439bfcae805274780, type: 2}
   m_StaticBatchInfo:
@@ -263,8 +263,8 @@ MeshRenderer:
   m_CastShadows: 2
   m_ReceiveShadows: 1
   m_MotionVectors: 1
-  m_LightProbeUsage: 1
-  m_ReflectionProbeUsage: 1
+  m_LightProbeUsage: 0
+  m_ReflectionProbeUsage: 0
   m_Materials:
   - {fileID: 2100000, guid: 000c9daec349fad439bfcae805274780, type: 2}
   m_StaticBatchInfo:
@@ -298,20 +298,6 @@ MeshFilter:
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 1000220028187964}
-  m_Mesh: {fileID: 4300000, guid: e361a35c4ad48cd4cb50e9f3665c712b, type: 3}
---- !u!64 &64657229832120198
-MeshCollider:
-  m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 1000220028187964}
-  m_Material: {fileID: 0}
-  m_IsTrigger: 0
-  m_Enabled: 1
-  serializedVersion: 2
-  m_Convex: 1
-  m_InflateMesh: 0
-  m_SkinWidth: 0.01
   m_Mesh: {fileID: 4300000, guid: e361a35c4ad48cd4cb50e9f3665c712b, type: 3}
 --- !u!65 &65871033734800222
 BoxCollider:
@@ -526,6 +512,18 @@ SphereCollider:
   serializedVersion: 2
   m_Radius: 3
   m_Center: {x: 0, y: 0, z: 0}
+--- !u!135 &135960341593254118
+SphereCollider:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1000220028187964}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Radius: 2
+  m_Center: {x: 0, y: 0.8, z: 0}
 --- !u!198 &198189217659864960
 ParticleSystem:
   m_ObjectHideFlags: 1

--- a/Assets/Prefabs/GamePlay/Items/Eshian Schteel.prefab
+++ b/Assets/Prefabs/GamePlay/Items/Eshian Schteel.prefab
@@ -71,8 +71,8 @@ GameObject:
   - component: {fileID: 4046137877949736}
   - component: {fileID: 33193532346860226}
   - component: {fileID: 23379784264131354}
-  - component: {fileID: 64097355699308436}
   - component: {fileID: 114429851283286504}
+  - component: {fileID: 135652644573376544}
   m_Layer: 0
   m_Name: Model
   m_TagString: Untagged
@@ -185,7 +185,7 @@ Transform:
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 1340948407090704}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 176.2, y: 1, z: 5.6}
+  m_LocalPosition: {x: 40.1, y: 1, z: -28.9}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
   - {fileID: 4046137877949736}
@@ -231,8 +231,8 @@ MeshRenderer:
   m_CastShadows: 2
   m_ReceiveShadows: 1
   m_MotionVectors: 1
-  m_LightProbeUsage: 1
-  m_ReflectionProbeUsage: 1
+  m_LightProbeUsage: 0
+  m_ReflectionProbeUsage: 0
   m_Materials:
   - {fileID: 2100000, guid: 000c9daec349fad439bfcae805274780, type: 2}
   m_StaticBatchInfo:
@@ -263,8 +263,8 @@ MeshRenderer:
   m_CastShadows: 2
   m_ReceiveShadows: 1
   m_MotionVectors: 1
-  m_LightProbeUsage: 1
-  m_ReflectionProbeUsage: 1
+  m_LightProbeUsage: 0
+  m_ReflectionProbeUsage: 0
   m_Materials:
   - {fileID: 2100000, guid: 000c9daec349fad439bfcae805274780, type: 2}
   m_StaticBatchInfo:
@@ -299,20 +299,6 @@ MeshFilter:
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 1869059811827550}
   m_Mesh: {fileID: 4300000, guid: 1aff5d326b830c945a5c0d54fef16a83, type: 3}
---- !u!64 &64097355699308436
-MeshCollider:
-  m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 1300944782026254}
-  m_Material: {fileID: 0}
-  m_IsTrigger: 0
-  m_Enabled: 1
-  serializedVersion: 2
-  m_Convex: 1
-  m_InflateMesh: 0
-  m_SkinWidth: 0.01
-  m_Mesh: {fileID: 4300000, guid: ffdee5900c09e7742b9969eecab4f7a8, type: 3}
 --- !u!65 &65159898774405506
 BoxCollider:
   m_ObjectHideFlags: 1
@@ -526,6 +512,18 @@ SphereCollider:
   serializedVersion: 2
   m_Radius: 3
   m_Center: {x: 0, y: 0, z: 0}
+--- !u!135 &135652644573376544
+SphereCollider:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1300944782026254}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Radius: 2
+  m_Center: {x: 0, y: 1.45, z: 0}
 --- !u!198 &198099286675877830
 ParticleSystem:
   m_ObjectHideFlags: 1

--- a/Assets/Prefabs/GamePlay/Items/Kreasten Kebabish.prefab
+++ b/Assets/Prefabs/GamePlay/Items/Kreasten Kebabish.prefab
@@ -89,8 +89,8 @@ GameObject:
   - component: {fileID: 4176234517466356}
   - component: {fileID: 33240650871511078}
   - component: {fileID: 23013741266220660}
-  - component: {fileID: 64395773364176476}
   - component: {fileID: 114027617985706826}
+  - component: {fileID: 135026008399407858}
   m_Layer: 0
   m_Name: Model
   m_TagString: Untagged
@@ -171,7 +171,7 @@ Transform:
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 1912495704433784}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: -51.5, y: 1, z: -50.8}
+  m_LocalPosition: {x: -51.7, y: 1, z: 5}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
   - {fileID: 4176234517466356}
@@ -231,8 +231,8 @@ MeshRenderer:
   m_CastShadows: 2
   m_ReceiveShadows: 1
   m_MotionVectors: 1
-  m_LightProbeUsage: 1
-  m_ReflectionProbeUsage: 1
+  m_LightProbeUsage: 0
+  m_ReflectionProbeUsage: 0
   m_Materials:
   - {fileID: 2100000, guid: 000c9daec349fad439bfcae805274780, type: 2}
   m_StaticBatchInfo:
@@ -263,8 +263,8 @@ MeshRenderer:
   m_CastShadows: 2
   m_ReceiveShadows: 1
   m_MotionVectors: 1
-  m_LightProbeUsage: 1
-  m_ReflectionProbeUsage: 1
+  m_LightProbeUsage: 0
+  m_ReflectionProbeUsage: 0
   m_Materials:
   - {fileID: 2100000, guid: 000c9daec349fad439bfcae805274780, type: 2}
   m_StaticBatchInfo:
@@ -298,20 +298,6 @@ MeshFilter:
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 1604947668005690}
-  m_Mesh: {fileID: 4300000, guid: 7e0bf473d1f3bfe4fa691f1a102b648d, type: 3}
---- !u!64 &64395773364176476
-MeshCollider:
-  m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 1604947668005690}
-  m_Material: {fileID: 0}
-  m_IsTrigger: 0
-  m_Enabled: 1
-  serializedVersion: 2
-  m_Convex: 1
-  m_InflateMesh: 0
-  m_SkinWidth: 0.01
   m_Mesh: {fileID: 4300000, guid: 7e0bf473d1f3bfe4fa691f1a102b648d, type: 3}
 --- !u!65 &65140974771309014
 BoxCollider:
@@ -514,6 +500,18 @@ MonoBehaviour:
   m_FillAmount: 1
   m_FillClockwise: 1
   m_FillOrigin: 0
+--- !u!135 &135026008399407858
+SphereCollider:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1604947668005690}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Radius: 2
+  m_Center: {x: 0, y: 1.4, z: 0}
 --- !u!135 &135844289530151938
 SphereCollider:
   m_ObjectHideFlags: 1

--- a/Assets/Prefabs/GamePlay/Items/Nusuathil Node.prefab
+++ b/Assets/Prefabs/GamePlay/Items/Nusuathil Node.prefab
@@ -142,8 +142,8 @@ GameObject:
   - component: {fileID: 4047085614044824}
   - component: {fileID: 33749339596307142}
   - component: {fileID: 23950430856033804}
-  - component: {fileID: 64104766545512412}
   - component: {fileID: 114385330374101400}
+  - component: {fileID: 135011954204647228}
   m_Layer: 0
   m_Name: Model
   m_TagString: Untagged
@@ -231,8 +231,8 @@ MeshRenderer:
   m_CastShadows: 2
   m_ReceiveShadows: 1
   m_MotionVectors: 1
-  m_LightProbeUsage: 1
-  m_ReflectionProbeUsage: 1
+  m_LightProbeUsage: 0
+  m_ReflectionProbeUsage: 0
   m_Materials:
   - {fileID: 2100000, guid: 000c9daec349fad439bfcae805274780, type: 2}
   m_StaticBatchInfo:
@@ -263,8 +263,8 @@ MeshRenderer:
   m_CastShadows: 2
   m_ReceiveShadows: 1
   m_MotionVectors: 1
-  m_LightProbeUsage: 1
-  m_ReflectionProbeUsage: 1
+  m_LightProbeUsage: 0
+  m_ReflectionProbeUsage: 0
   m_Materials:
   - {fileID: 2100000, guid: 000c9daec349fad439bfcae805274780, type: 2}
   m_StaticBatchInfo:
@@ -298,20 +298,6 @@ MeshFilter:
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 1935782230554044}
-  m_Mesh: {fileID: 4300000, guid: ffb3a643486a89f4f86007d3e229a57c, type: 3}
---- !u!64 &64104766545512412
-MeshCollider:
-  m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 1935782230554044}
-  m_Material: {fileID: 0}
-  m_IsTrigger: 0
-  m_Enabled: 1
-  serializedVersion: 2
-  m_Convex: 1
-  m_InflateMesh: 0
-  m_SkinWidth: 0.01
   m_Mesh: {fileID: 4300000, guid: ffb3a643486a89f4f86007d3e229a57c, type: 3}
 --- !u!65 &65992349037103094
 BoxCollider:
@@ -514,6 +500,18 @@ MonoBehaviour:
   m_BlockingMask:
     serializedVersion: 2
     m_Bits: 4294967295
+--- !u!135 &135011954204647228
+SphereCollider:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1935782230554044}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Radius: 2
+  m_Center: {x: 0, y: 0.5, z: 0}
 --- !u!135 &135671701554734254
 SphereCollider:
   m_ObjectHideFlags: 1

--- a/Assets/Prefabs/GamePlay/Items/Qustralt Qush.prefab
+++ b/Assets/Prefabs/GamePlay/Items/Qustralt Qush.prefab
@@ -39,8 +39,8 @@ GameObject:
   - component: {fileID: 4025359131623780}
   - component: {fileID: 33634413294478882}
   - component: {fileID: 23449205620278898}
-  - component: {fileID: 64024424314458012}
   - component: {fileID: 114864307652806220}
+  - component: {fileID: 135009142597698412}
   m_Layer: 0
   m_Name: Model
   m_TagString: Untagged
@@ -172,7 +172,7 @@ Transform:
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 1150427940132806}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: -33.6, y: 1, z: -105.4}
+  m_LocalPosition: {x: -14.7, y: 1, z: -45.7}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
   - {fileID: 4025359131623780}
@@ -231,8 +231,8 @@ MeshRenderer:
   m_CastShadows: 2
   m_ReceiveShadows: 1
   m_MotionVectors: 1
-  m_LightProbeUsage: 1
-  m_ReflectionProbeUsage: 1
+  m_LightProbeUsage: 0
+  m_ReflectionProbeUsage: 0
   m_Materials:
   - {fileID: 2100000, guid: 000c9daec349fad439bfcae805274780, type: 2}
   m_StaticBatchInfo:
@@ -263,8 +263,8 @@ MeshRenderer:
   m_CastShadows: 2
   m_ReceiveShadows: 1
   m_MotionVectors: 1
-  m_LightProbeUsage: 1
-  m_ReflectionProbeUsage: 1
+  m_LightProbeUsage: 0
+  m_ReflectionProbeUsage: 0
   m_Materials:
   - {fileID: 2100000, guid: 000c9daec349fad439bfcae805274780, type: 2}
   m_StaticBatchInfo:
@@ -298,20 +298,6 @@ MeshFilter:
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 1090717103945108}
-  m_Mesh: {fileID: 4300000, guid: d9a9be4c75b2f1a47888a1267437bdae, type: 3}
---- !u!64 &64024424314458012
-MeshCollider:
-  m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 1090717103945108}
-  m_Material: {fileID: 0}
-  m_IsTrigger: 0
-  m_Enabled: 1
-  serializedVersion: 2
-  m_Convex: 1
-  m_InflateMesh: 0
-  m_SkinWidth: 0.01
   m_Mesh: {fileID: 4300000, guid: d9a9be4c75b2f1a47888a1267437bdae, type: 3}
 --- !u!65 &65335350507295900
 BoxCollider:
@@ -514,6 +500,18 @@ MonoBehaviour:
     m_VerticalOverflow: 0
     m_LineSpacing: 1
   m_Text: Qustralt Qush
+--- !u!135 &135009142597698412
+SphereCollider:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1090717103945108}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Radius: 2
+  m_Center: {x: 0, y: 1.6, z: 0}
 --- !u!135 &135173786016020078
 SphereCollider:
   m_ObjectHideFlags: 1

--- a/Assets/Prefabs/GamePlay/Items/Skudian Plumbus.prefab
+++ b/Assets/Prefabs/GamePlay/Items/Skudian Plumbus.prefab
@@ -21,8 +21,8 @@ GameObject:
   - component: {fileID: 4079328426761228}
   - component: {fileID: 33056253192431490}
   - component: {fileID: 23142397786631518}
-  - component: {fileID: 64411246533969720}
   - component: {fileID: 114488839298280632}
+  - component: {fileID: 135237206372082362}
   m_Layer: 0
   m_Name: Model
   m_TagString: Untagged
@@ -199,7 +199,7 @@ Transform:
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 1825967513655166}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 2.1, y: 1, z: -87.4}
+  m_LocalPosition: {x: -64.5, y: 1, z: -12.2}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
   - {fileID: 4079328426761228}
@@ -231,8 +231,8 @@ MeshRenderer:
   m_CastShadows: 2
   m_ReceiveShadows: 1
   m_MotionVectors: 1
-  m_LightProbeUsage: 1
-  m_ReflectionProbeUsage: 1
+  m_LightProbeUsage: 0
+  m_ReflectionProbeUsage: 0
   m_Materials:
   - {fileID: 2100000, guid: 000c9daec349fad439bfcae805274780, type: 2}
   m_StaticBatchInfo:
@@ -263,8 +263,8 @@ MeshRenderer:
   m_CastShadows: 2
   m_ReceiveShadows: 1
   m_MotionVectors: 1
-  m_LightProbeUsage: 1
-  m_ReflectionProbeUsage: 1
+  m_LightProbeUsage: 0
+  m_ReflectionProbeUsage: 0
   m_Materials:
   - {fileID: 2100000, guid: 000c9daec349fad439bfcae805274780, type: 2}
   m_StaticBatchInfo:
@@ -299,20 +299,6 @@ MeshFilter:
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 1789573088595032}
   m_Mesh: {fileID: 4300000, guid: 1aff5d326b830c945a5c0d54fef16a83, type: 3}
---- !u!64 &64411246533969720
-MeshCollider:
-  m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 1238917945226224}
-  m_Material: {fileID: 0}
-  m_IsTrigger: 0
-  m_Enabled: 1
-  serializedVersion: 2
-  m_Convex: 1
-  m_InflateMesh: 0
-  m_SkinWidth: 0.01
-  m_Mesh: {fileID: 4300000, guid: 72079b96b9dddbe4485022b8732243b5, type: 3}
 --- !u!65 &65411420319080044
 BoxCollider:
   m_ObjectHideFlags: 1
@@ -526,6 +512,18 @@ SphereCollider:
   serializedVersion: 2
   m_Radius: 3
   m_Center: {x: 0, y: 0, z: 0}
+--- !u!135 &135237206372082362
+SphereCollider:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1238917945226224}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Radius: 2
+  m_Center: {x: 0, y: 1, z: 0}
 --- !u!198 &198623646943941776
 ParticleSystem:
   m_ObjectHideFlags: 1

--- a/Assets/Prefabs/GamePlay/Items/Transcendent Tryytium.prefab
+++ b/Assets/Prefabs/GamePlay/Items/Transcendent Tryytium.prefab
@@ -53,8 +53,8 @@ GameObject:
   - component: {fileID: 4797103278114442}
   - component: {fileID: 33215751096749568}
   - component: {fileID: 23155562002495316}
-  - component: {fileID: 64543454428967362}
   - component: {fileID: 114342122094325444}
+  - component: {fileID: 135647701600615374}
   m_Layer: 0
   m_Name: Model
   m_TagString: Untagged
@@ -158,7 +158,7 @@ Transform:
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 1643999685934340}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 75, y: 1, z: -161.1}
+  m_LocalPosition: {x: 12.5, y: 1, z: -37.6}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
   - {fileID: 4797103278114442}
@@ -231,8 +231,8 @@ MeshRenderer:
   m_CastShadows: 2
   m_ReceiveShadows: 1
   m_MotionVectors: 1
-  m_LightProbeUsage: 1
-  m_ReflectionProbeUsage: 1
+  m_LightProbeUsage: 0
+  m_ReflectionProbeUsage: 0
   m_Materials:
   - {fileID: 2100000, guid: 000c9daec349fad439bfcae805274780, type: 2}
   m_StaticBatchInfo:
@@ -263,8 +263,8 @@ MeshRenderer:
   m_CastShadows: 2
   m_ReceiveShadows: 1
   m_MotionVectors: 1
-  m_LightProbeUsage: 1
-  m_ReflectionProbeUsage: 1
+  m_LightProbeUsage: 0
+  m_ReflectionProbeUsage: 0
   m_Materials:
   - {fileID: 2100000, guid: 000c9daec349fad439bfcae805274780, type: 2}
   m_StaticBatchInfo:
@@ -299,20 +299,6 @@ MeshFilter:
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 1821650311184232}
   m_Mesh: {fileID: 4300000, guid: 1aff5d326b830c945a5c0d54fef16a83, type: 3}
---- !u!64 &64543454428967362
-MeshCollider:
-  m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 1202899624562074}
-  m_Material: {fileID: 0}
-  m_IsTrigger: 0
-  m_Enabled: 1
-  serializedVersion: 2
-  m_Convex: 1
-  m_InflateMesh: 0
-  m_SkinWidth: 0.01
-  m_Mesh: {fileID: 4300000, guid: 7a7b66ca7aa897e4faa32978d9e79593, type: 3}
 --- !u!65 &65977779256356630
 BoxCollider:
   m_ObjectHideFlags: 1
@@ -514,6 +500,18 @@ MonoBehaviour:
   m_EffectColor: {r: 0, g: 0, b: 0, a: 1}
   m_EffectDistance: {x: 6, y: 6}
   m_UseGraphicAlpha: 1
+--- !u!135 &135647701600615374
+SphereCollider:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1202899624562074}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Radius: 2
+  m_Center: {x: 0, y: 0.75, z: 0}
 --- !u!135 &135663067498791572
 SphereCollider:
   m_ObjectHideFlags: 1

--- a/Assets/Prefabs/GamePlay/Items/Ublyx Lexicon.prefab
+++ b/Assets/Prefabs/GamePlay/Items/Ublyx Lexicon.prefab
@@ -91,8 +91,8 @@ GameObject:
   - component: {fileID: 4493986874560214}
   - component: {fileID: 33217504648223390}
   - component: {fileID: 23250672368571488}
-  - component: {fileID: 64765951350463292}
   - component: {fileID: 114005357506318940}
+  - component: {fileID: 135601462676195074}
   m_Layer: 0
   m_Name: Model
   m_TagString: Untagged
@@ -185,7 +185,7 @@ Transform:
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 1031770116693876}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 106.3, y: 1, z: -58.7}
+  m_LocalPosition: {x: -19.9, y: 1, z: -13.9}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
   - {fileID: 4493986874560214}
@@ -231,8 +231,8 @@ MeshRenderer:
   m_CastShadows: 2
   m_ReceiveShadows: 1
   m_MotionVectors: 1
-  m_LightProbeUsage: 1
-  m_ReflectionProbeUsage: 1
+  m_LightProbeUsage: 0
+  m_ReflectionProbeUsage: 0
   m_Materials:
   - {fileID: 2100000, guid: 000c9daec349fad439bfcae805274780, type: 2}
   m_StaticBatchInfo:
@@ -263,8 +263,8 @@ MeshRenderer:
   m_CastShadows: 2
   m_ReceiveShadows: 1
   m_MotionVectors: 1
-  m_LightProbeUsage: 1
-  m_ReflectionProbeUsage: 1
+  m_LightProbeUsage: 0
+  m_ReflectionProbeUsage: 0
   m_Materials:
   - {fileID: 2100000, guid: 000c9daec349fad439bfcae805274780, type: 2}
   m_StaticBatchInfo:
@@ -299,20 +299,6 @@ MeshFilter:
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 1082368278943294}
   m_Mesh: {fileID: 4300000, guid: 1aff5d326b830c945a5c0d54fef16a83, type: 3}
---- !u!64 &64765951350463292
-MeshCollider:
-  m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 1280958941390294}
-  m_Material: {fileID: 0}
-  m_IsTrigger: 0
-  m_Enabled: 1
-  serializedVersion: 2
-  m_Convex: 1
-  m_InflateMesh: 0
-  m_SkinWidth: 0.01
-  m_Mesh: {fileID: 4300000, guid: 91a4c86e838ece141bd58a64b0b90c9f, type: 3}
 --- !u!65 &65964026475399058
 BoxCollider:
   m_ObjectHideFlags: 1
@@ -514,6 +500,18 @@ MonoBehaviour:
   m_BlockingMask:
     serializedVersion: 2
     m_Bits: 4294967295
+--- !u!135 &135601462676195074
+SphereCollider:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1280958941390294}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Radius: 2
+  m_Center: {x: 0, y: 0.6, z: 0}
 --- !u!135 &135696435165687888
 SphereCollider:
   m_ObjectHideFlags: 1

--- a/Assets/Prefabs/GamePlay/Items/Vufrum Voxel.prefab
+++ b/Assets/Prefabs/GamePlay/Items/Vufrum Voxel.prefab
@@ -39,8 +39,8 @@ GameObject:
   - component: {fileID: 4201233544238272}
   - component: {fileID: 33882976641956226}
   - component: {fileID: 23374171752706576}
-  - component: {fileID: 64551190791437384}
   - component: {fileID: 114063134911533470}
+  - component: {fileID: 135603263959077766}
   m_Layer: 0
   m_Name: Model
   m_TagString: Untagged
@@ -185,7 +185,7 @@ Transform:
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 1248998017156364}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 47.8, y: 1, z: -26.5}
+  m_LocalPosition: {x: 50.3, y: 1, z: -10.4}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
   - {fileID: 4201233544238272}
@@ -231,8 +231,8 @@ MeshRenderer:
   m_CastShadows: 2
   m_ReceiveShadows: 1
   m_MotionVectors: 1
-  m_LightProbeUsage: 1
-  m_ReflectionProbeUsage: 1
+  m_LightProbeUsage: 0
+  m_ReflectionProbeUsage: 0
   m_Materials:
   - {fileID: 2100000, guid: 000c9daec349fad439bfcae805274780, type: 2}
   m_StaticBatchInfo:
@@ -263,8 +263,8 @@ MeshRenderer:
   m_CastShadows: 2
   m_ReceiveShadows: 1
   m_MotionVectors: 1
-  m_LightProbeUsage: 1
-  m_ReflectionProbeUsage: 1
+  m_LightProbeUsage: 0
+  m_ReflectionProbeUsage: 0
   m_Materials:
   - {fileID: 2100000, guid: 000c9daec349fad439bfcae805274780, type: 2}
   m_StaticBatchInfo:
@@ -299,20 +299,6 @@ MeshFilter:
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 1372946289839174}
   m_Mesh: {fileID: 4300000, guid: 1aff5d326b830c945a5c0d54fef16a83, type: 3}
---- !u!64 &64551190791437384
-MeshCollider:
-  m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 1212044192528614}
-  m_Material: {fileID: 0}
-  m_IsTrigger: 0
-  m_Enabled: 1
-  serializedVersion: 2
-  m_Convex: 1
-  m_InflateMesh: 0
-  m_SkinWidth: 0.01
-  m_Mesh: {fileID: 4300000, guid: c23fd317badea9e40bf786140feb5023, type: 3}
 --- !u!65 &65449669655938762
 BoxCollider:
   m_ObjectHideFlags: 1
@@ -526,6 +512,18 @@ SphereCollider:
   serializedVersion: 2
   m_Radius: 3
   m_Center: {x: 0, y: 0, z: 0}
+--- !u!135 &135603263959077766
+SphereCollider:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1212044192528614}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Radius: 2
+  m_Center: {x: 0, y: 0.5, z: 0}
 --- !u!198 &198712797961237970
 ParticleSystem:
   m_ObjectHideFlags: 1

--- a/Assets/Prefabs/GamePlay/Items/Zushese Shuzuu.prefab
+++ b/Assets/Prefabs/GamePlay/Items/Zushese Shuzuu.prefab
@@ -39,8 +39,8 @@ GameObject:
   - component: {fileID: 4607178057372024}
   - component: {fileID: 33281338298889934}
   - component: {fileID: 23368706989507194}
-  - component: {fileID: 64097500963660398}
   - component: {fileID: 114940233234475956}
+  - component: {fileID: 135310237329013628}
   m_Layer: 0
   m_Name: Model
   m_TagString: Untagged
@@ -185,7 +185,7 @@ Transform:
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 1396216008526434}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: -14.2, y: 1, z: 4.2}
+  m_LocalPosition: {x: 20.54, y: 1, z: 19.37}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
   - {fileID: 4607178057372024}
@@ -231,8 +231,8 @@ MeshRenderer:
   m_CastShadows: 2
   m_ReceiveShadows: 1
   m_MotionVectors: 1
-  m_LightProbeUsage: 1
-  m_ReflectionProbeUsage: 1
+  m_LightProbeUsage: 0
+  m_ReflectionProbeUsage: 0
   m_Materials:
   - {fileID: 2100000, guid: 000c9daec349fad439bfcae805274780, type: 2}
   m_StaticBatchInfo:
@@ -263,8 +263,8 @@ MeshRenderer:
   m_CastShadows: 2
   m_ReceiveShadows: 1
   m_MotionVectors: 1
-  m_LightProbeUsage: 1
-  m_ReflectionProbeUsage: 1
+  m_LightProbeUsage: 0
+  m_ReflectionProbeUsage: 0
   m_Materials:
   - {fileID: 2100000, guid: 000c9daec349fad439bfcae805274780, type: 2}
   m_StaticBatchInfo:
@@ -299,20 +299,6 @@ MeshFilter:
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 1674781739484872}
   m_Mesh: {fileID: 4300000, guid: 1aff5d326b830c945a5c0d54fef16a83, type: 3}
---- !u!64 &64097500963660398
-MeshCollider:
-  m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 1347045068853392}
-  m_Material: {fileID: 0}
-  m_IsTrigger: 0
-  m_Enabled: 1
-  serializedVersion: 2
-  m_Convex: 1
-  m_InflateMesh: 0
-  m_SkinWidth: 0.01
-  m_Mesh: {fileID: 4300000, guid: 0f99ca1e7852e7b4db1ef781b727c919, type: 3}
 --- !u!65 &65428975067281210
 BoxCollider:
   m_ObjectHideFlags: 1
@@ -526,6 +512,18 @@ SphereCollider:
   serializedVersion: 2
   m_Radius: 3
   m_Center: {x: 0, y: 0, z: 0}
+--- !u!135 &135310237329013628
+SphereCollider:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1347045068853392}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Radius: 2
+  m_Center: {x: 0, y: 0.45000002, z: 0}
 --- !u!198 &198652570048481768
 ParticleSystem:
   m_ObjectHideFlags: 1

--- a/Assets/Scenes/Scene_1.unity
+++ b/Assets/Scenes/Scene_1.unity
@@ -1162,34 +1162,6 @@ Prefab:
       propertyPath: m_RootOrder
       value: 8
       objectReference: {fileID: 0}
-    - target: {fileID: 1372946289839174, guid: 1290276cd83235047a736c2e31a8af56, type: 2}
-      propertyPath: m_StaticEditorFlags
-      value: 8
-      objectReference: {fileID: 0}
-    - target: {fileID: 1212044192528614, guid: 1290276cd83235047a736c2e31a8af56, type: 2}
-      propertyPath: m_StaticEditorFlags
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 23374171752706576, guid: 1290276cd83235047a736c2e31a8af56,
-        type: 2}
-      propertyPath: m_LightProbeUsage
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 23928165224225354, guid: 1290276cd83235047a736c2e31a8af56,
-        type: 2}
-      propertyPath: m_LightProbeUsage
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 23374171752706576, guid: 1290276cd83235047a736c2e31a8af56,
-        type: 2}
-      propertyPath: m_ReflectionProbeUsage
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 23928165224225354, guid: 1290276cd83235047a736c2e31a8af56,
-        type: 2}
-      propertyPath: m_ReflectionProbeUsage
-      value: 0
-      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_ParentPrefab: {fileID: 100100000, guid: 1290276cd83235047a736c2e31a8af56, type: 2}
   m_IsPrefabParent: 0
@@ -2932,34 +2904,6 @@ Prefab:
       propertyPath: m_RootOrder
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 1300944782026254, guid: fb0f0365f08b9434185ae325bfe3aea5, type: 2}
-      propertyPath: m_StaticEditorFlags
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1869059811827550, guid: fb0f0365f08b9434185ae325bfe3aea5, type: 2}
-      propertyPath: m_StaticEditorFlags
-      value: 8
-      objectReference: {fileID: 0}
-    - target: {fileID: 23046047195954230, guid: fb0f0365f08b9434185ae325bfe3aea5,
-        type: 2}
-      propertyPath: m_LightProbeUsage
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 23379784264131354, guid: fb0f0365f08b9434185ae325bfe3aea5,
-        type: 2}
-      propertyPath: m_LightProbeUsage
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 23046047195954230, guid: fb0f0365f08b9434185ae325bfe3aea5,
-        type: 2}
-      propertyPath: m_ReflectionProbeUsage
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 23379784264131354, guid: fb0f0365f08b9434185ae325bfe3aea5,
-        type: 2}
-      propertyPath: m_ReflectionProbeUsage
-      value: 0
-      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_ParentPrefab: {fileID: 100100000, guid: fb0f0365f08b9434185ae325bfe3aea5, type: 2}
   m_IsPrefabParent: 0
@@ -3381,34 +3325,6 @@ Prefab:
       propertyPath: m_RootOrder
       value: 4
       objectReference: {fileID: 0}
-    - target: {fileID: 1090717103945108, guid: 3fd624521291aa0419f7d9a40a79f788, type: 2}
-      propertyPath: m_StaticEditorFlags
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1888723402661700, guid: 3fd624521291aa0419f7d9a40a79f788, type: 2}
-      propertyPath: m_StaticEditorFlags
-      value: 8
-      objectReference: {fileID: 0}
-    - target: {fileID: 23493544866056384, guid: 3fd624521291aa0419f7d9a40a79f788,
-        type: 2}
-      propertyPath: m_LightProbeUsage
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 23449205620278898, guid: 3fd624521291aa0419f7d9a40a79f788,
-        type: 2}
-      propertyPath: m_LightProbeUsage
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 23493544866056384, guid: 3fd624521291aa0419f7d9a40a79f788,
-        type: 2}
-      propertyPath: m_ReflectionProbeUsage
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 23449205620278898, guid: 3fd624521291aa0419f7d9a40a79f788,
-        type: 2}
-      propertyPath: m_ReflectionProbeUsage
-      value: 0
-      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_ParentPrefab: {fileID: 100100000, guid: 3fd624521291aa0419f7d9a40a79f788, type: 2}
   m_IsPrefabParent: 0
@@ -3455,34 +3371,6 @@ Prefab:
     - target: {fileID: 4000653703410414, guid: a6be732a2c24ff549966146947fafb98, type: 2}
       propertyPath: m_RootOrder
       value: 6
-      objectReference: {fileID: 0}
-    - target: {fileID: 1202899624562074, guid: a6be732a2c24ff549966146947fafb98, type: 2}
-      propertyPath: m_StaticEditorFlags
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1821650311184232, guid: a6be732a2c24ff549966146947fafb98, type: 2}
-      propertyPath: m_StaticEditorFlags
-      value: 8
-      objectReference: {fileID: 0}
-    - target: {fileID: 23653666710485194, guid: a6be732a2c24ff549966146947fafb98,
-        type: 2}
-      propertyPath: m_LightProbeUsage
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 23155562002495316, guid: a6be732a2c24ff549966146947fafb98,
-        type: 2}
-      propertyPath: m_LightProbeUsage
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 23653666710485194, guid: a6be732a2c24ff549966146947fafb98,
-        type: 2}
-      propertyPath: m_ReflectionProbeUsage
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 23155562002495316, guid: a6be732a2c24ff549966146947fafb98,
-        type: 2}
-      propertyPath: m_ReflectionProbeUsage
-      value: 0
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_ParentPrefab: {fileID: 100100000, guid: a6be732a2c24ff549966146947fafb98, type: 2}
@@ -4458,34 +4346,6 @@ Prefab:
       propertyPath: m_RootOrder
       value: 5
       objectReference: {fileID: 0}
-    - target: {fileID: 1238917945226224, guid: fc451f45998c2f6438c0c3413377042a, type: 2}
-      propertyPath: m_StaticEditorFlags
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1789573088595032, guid: fc451f45998c2f6438c0c3413377042a, type: 2}
-      propertyPath: m_StaticEditorFlags
-      value: 8
-      objectReference: {fileID: 0}
-    - target: {fileID: 23142397786631518, guid: fc451f45998c2f6438c0c3413377042a,
-        type: 2}
-      propertyPath: m_LightProbeUsage
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 23126864414378080, guid: fc451f45998c2f6438c0c3413377042a,
-        type: 2}
-      propertyPath: m_LightProbeUsage
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 23142397786631518, guid: fc451f45998c2f6438c0c3413377042a,
-        type: 2}
-      propertyPath: m_ReflectionProbeUsage
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 23126864414378080, guid: fc451f45998c2f6438c0c3413377042a,
-        type: 2}
-      propertyPath: m_ReflectionProbeUsage
-      value: 0
-      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_ParentPrefab: {fileID: 100100000, guid: fc451f45998c2f6438c0c3413377042a, type: 2}
   m_IsPrefabParent: 0
@@ -5317,34 +5177,6 @@ Prefab:
       propertyPath: m_RootOrder
       value: 2
       objectReference: {fileID: 0}
-    - target: {fileID: 1604947668005690, guid: df504d46c0765684ba72959af9765934, type: 2}
-      propertyPath: m_StaticEditorFlags
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1803257940911340, guid: df504d46c0765684ba72959af9765934, type: 2}
-      propertyPath: m_StaticEditorFlags
-      value: 8
-      objectReference: {fileID: 0}
-    - target: {fileID: 23013741266220660, guid: df504d46c0765684ba72959af9765934,
-        type: 2}
-      propertyPath: m_LightProbeUsage
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 23260080452377194, guid: df504d46c0765684ba72959af9765934,
-        type: 2}
-      propertyPath: m_LightProbeUsage
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 23013741266220660, guid: df504d46c0765684ba72959af9765934,
-        type: 2}
-      propertyPath: m_ReflectionProbeUsage
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 23260080452377194, guid: df504d46c0765684ba72959af9765934,
-        type: 2}
-      propertyPath: m_ReflectionProbeUsage
-      value: 0
-      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_ParentPrefab: {fileID: 100100000, guid: df504d46c0765684ba72959af9765934, type: 2}
   m_IsPrefabParent: 0
@@ -5391,34 +5223,6 @@ Prefab:
     - target: {fileID: 4574926530927854, guid: d20f63ee15280b746a8f672a7158daad, type: 2}
       propertyPath: m_RootOrder
       value: 7
-      objectReference: {fileID: 0}
-    - target: {fileID: 1280958941390294, guid: d20f63ee15280b746a8f672a7158daad, type: 2}
-      propertyPath: m_StaticEditorFlags
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1082368278943294, guid: d20f63ee15280b746a8f672a7158daad, type: 2}
-      propertyPath: m_StaticEditorFlags
-      value: 8
-      objectReference: {fileID: 0}
-    - target: {fileID: 23318351774140010, guid: d20f63ee15280b746a8f672a7158daad,
-        type: 2}
-      propertyPath: m_LightProbeUsage
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 23250672368571488, guid: d20f63ee15280b746a8f672a7158daad,
-        type: 2}
-      propertyPath: m_LightProbeUsage
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 23318351774140010, guid: d20f63ee15280b746a8f672a7158daad,
-        type: 2}
-      propertyPath: m_ReflectionProbeUsage
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 23250672368571488, guid: d20f63ee15280b746a8f672a7158daad,
-        type: 2}
-      propertyPath: m_ReflectionProbeUsage
-      value: 0
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_ParentPrefab: {fileID: 100100000, guid: d20f63ee15280b746a8f672a7158daad, type: 2}
@@ -5492,34 +5296,6 @@ Prefab:
     - target: {fileID: 4097658127163820, guid: a5db87b28e534ce47986ef989e695240, type: 2}
       propertyPath: m_RootOrder
       value: 9
-      objectReference: {fileID: 0}
-    - target: {fileID: 1347045068853392, guid: a5db87b28e534ce47986ef989e695240, type: 2}
-      propertyPath: m_StaticEditorFlags
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1674781739484872, guid: a5db87b28e534ce47986ef989e695240, type: 2}
-      propertyPath: m_StaticEditorFlags
-      value: 8
-      objectReference: {fileID: 0}
-    - target: {fileID: 23642587390971302, guid: a5db87b28e534ce47986ef989e695240,
-        type: 2}
-      propertyPath: m_LightProbeUsage
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 23368706989507194, guid: a5db87b28e534ce47986ef989e695240,
-        type: 2}
-      propertyPath: m_LightProbeUsage
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 23642587390971302, guid: a5db87b28e534ce47986ef989e695240,
-        type: 2}
-      propertyPath: m_ReflectionProbeUsage
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 23368706989507194, guid: a5db87b28e534ce47986ef989e695240,
-        type: 2}
-      propertyPath: m_ReflectionProbeUsage
-      value: 0
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_ParentPrefab: {fileID: 100100000, guid: a5db87b28e534ce47986ef989e695240, type: 2}
@@ -7339,34 +7115,6 @@ Prefab:
       propertyPath: m_RootOrder
       value: 3
       objectReference: {fileID: 0}
-    - target: {fileID: 1890035983642272, guid: 60e89f5081ebbc3408efa81138df0c2d, type: 2}
-      propertyPath: m_StaticEditorFlags
-      value: 8
-      objectReference: {fileID: 0}
-    - target: {fileID: 1935782230554044, guid: 60e89f5081ebbc3408efa81138df0c2d, type: 2}
-      propertyPath: m_StaticEditorFlags
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 23950430856033804, guid: 60e89f5081ebbc3408efa81138df0c2d,
-        type: 2}
-      propertyPath: m_LightProbeUsage
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 23718699889432654, guid: 60e89f5081ebbc3408efa81138df0c2d,
-        type: 2}
-      propertyPath: m_LightProbeUsage
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 23950430856033804, guid: 60e89f5081ebbc3408efa81138df0c2d,
-        type: 2}
-      propertyPath: m_ReflectionProbeUsage
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 23718699889432654, guid: 60e89f5081ebbc3408efa81138df0c2d,
-        type: 2}
-      propertyPath: m_ReflectionProbeUsage
-      value: 0
-      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_ParentPrefab: {fileID: 100100000, guid: 60e89f5081ebbc3408efa81138df0c2d, type: 2}
   m_IsPrefabParent: 0
@@ -7407,34 +7155,6 @@ Prefab:
       objectReference: {fileID: 0}
     - target: {fileID: 4978139228866592, guid: e3a7f3e5ca7924e489a1f8a6d6f7d494, type: 2}
       propertyPath: m_RootOrder
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1552750927778320, guid: e3a7f3e5ca7924e489a1f8a6d6f7d494, type: 2}
-      propertyPath: m_StaticEditorFlags
-      value: 8
-      objectReference: {fileID: 0}
-    - target: {fileID: 1000220028187964, guid: e3a7f3e5ca7924e489a1f8a6d6f7d494, type: 2}
-      propertyPath: m_StaticEditorFlags
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 23125762744368210, guid: e3a7f3e5ca7924e489a1f8a6d6f7d494,
-        type: 2}
-      propertyPath: m_LightProbeUsage
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 23023499580672582, guid: e3a7f3e5ca7924e489a1f8a6d6f7d494,
-        type: 2}
-      propertyPath: m_LightProbeUsage
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 23125762744368210, guid: e3a7f3e5ca7924e489a1f8a6d6f7d494,
-        type: 2}
-      propertyPath: m_ReflectionProbeUsage
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 23023499580672582, guid: e3a7f3e5ca7924e489a1f8a6d6f7d494,
-        type: 2}
-      propertyPath: m_ReflectionProbeUsage
       value: 0
       objectReference: {fileID: 0}
     m_RemovedComponents: []

--- a/ProjectSettings/ProjectSettings.asset
+++ b/ProjectSettings/ProjectSettings.asset
@@ -127,7 +127,7 @@ PlayerSettings:
     16:10: 1
     16:9: 1
     Others: 1
-  bundleVersion: 0.1.2.afc2366
+  bundleVersion: 0.1.2.5626f65
   preloadedAssets: []
   metroInputSource: 0
   m_HolographicPauseOnTrackingLoss: 1


### PR DESCRIPTION
Mesh colliders force a read/write enabled state on the meshes. Moved over to sphere colliders, which are also more efficient.